### PR TITLE
travis-ci: explicitly set pypy3 version to `pypy3.5-5.8.0`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
   - "3.7-dev"
   - "nightly"
   - "pypy"
-  - "pypy3"
+  - "pypy3.5-5.8.0"
 install:
     pip install nose coveralls coverage
 script:


### PR DESCRIPTION
Travis-CI uses an outdated pypy3 version, which contains some bugs when using multithreaded scripts.
Replacing `pypy3` in `.travis.yml` with `pypy3.5-5.8.0` enforces the newer pypy3 version.