### PR TITLE
enforce pypy3.5-5.8.0 on travis; add test; add docstring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
   - "3.7-dev"
   - "nightly"
   - "pypy"
-  - "pypy3"
+  - "pypy3.5-5.8.0"
 install:
     pip install nose coveralls coverage
 script:

--- a/examples/xor/evolve-feedforward-threaded.py
+++ b/examples/xor/evolve-feedforward-threaded.py
@@ -47,6 +47,7 @@ def eval_genome(genome, config):
 
 
 def run(config_file):
+    """load the config, create a population, evolve and show the result"""
     # Load configuration.
     config = neat.Config(neat.DefaultGenome, neat.DefaultReproduction,
                          neat.DefaultSpeciesSet, neat.DefaultStagnation,
@@ -63,6 +64,7 @@ def run(config_file):
     # Run for up to 300 generations.
     pe = neat.ThreadedEvaluator(4, eval_genome)
     winner = p.run(pe.evaluate, 300)
+    pe.stop()
 
     # Display the winning genome.
     print('\nBest genome:\n{!s}'.format(winner))

--- a/neat/threaded.py
+++ b/neat/threaded.py
@@ -25,7 +25,12 @@ class ThreadedEvaluator(object):
         self.outqueue = queue.Queue()
 
     def __del__(self):
-        """called on deletion of the object. We stop our workers here."""
+        """
+        Called on deletion of the object. We stop our workers here.
+        WARNING: __del__ may not always work!
+        please stop the threads explicitly by calling self.stop()!
+        todo: ensure that there are no reference-cycles.
+        """
         if self.working:
             self.stop()
             

--- a/neat/threaded.py
+++ b/neat/threaded.py
@@ -25,6 +25,7 @@ class ThreadedEvaluator(object):
         self.outqueue = queue.Queue()
 
     def __del__(self):
+        """called on deletion of the object. We stop our workers here."""
         if self.working:
             self.stop()
             
@@ -47,12 +48,16 @@ class ThreadedEvaluator(object):
         self.working = False
         for w in self.workers:
             w.join()
+        self.workers = []
 
     def _worker(self):
         """the worker function"""
         while self.working:
             try:
-                genome_id, genome, config = self.inqueue.get(block=True, timeout=0.2)
+                genome_id, genome, config = self.inqueue.get(
+                    block=True,
+                    timeout=0.2,
+                    )
             except queue.Empty:
                 continue
             f = self.eval_function(genome, config)

--- a/tests/test_simple_run.py
+++ b/tests/test_simple_run.py
@@ -141,10 +141,12 @@ def test_threaded_evaluator():
     if not w.is_alive():
         raise Exception("Workers did not start on start()")
     # ensure del stops workers
-    w = e.workers[0]
     del e
-    if w.is_alive():
-        raise Exception("__del__() did not stop workers!")
+    # unfortunately, __del__() may never be called, even when using del
+    # this means that testing for __del__() to call stop() may not work
+    # this test had a high random failure rate, so i removed it.
+    # if w.is_alive():
+    #     raise Exception("__del__() did not stop workers!")
 
 
 def eval_dummy_genomes_nn_recurrent(genomes, config):


### PR DESCRIPTION
Travis uses an old `pypy3` version which causes some threading bug during the build for https://github.com/CodeReclaimers/neat-python/pull/95.
Enforcing `pypy3.5-5.8.0` fixes this.
I added a test for general `neat.threaded.ThreadedEvaluator` functionality to improve coverage.
I also added a docstring to the `run()` function of the example.